### PR TITLE
Make set_time_zone about 50x faster when the time zone is provided as a string and hasn't changed

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1949,6 +1949,8 @@ sub set_time_zone {
     # are singletons, and if it doesn't work all we lose is a little
     # bit of speed.
     return $self if $self->{tz} eq $tz;
+    # Also short-circuit if a name is provided and the time zone hasn't changed
+    return $self  if $self->{tz}->name eq $tz;
 
     my $was_floating = $self->{tz}->is_floating;
 


### PR DESCRIPTION
set_time_zone already contains an optimization when the time zone is provided as an object, and is the same time zone the DateTime object already has. 

This patch adds an additional check for sameness when the time zone provided is a string. The benchmark below shows is to be about 50x faster for the case it covers.

```
use Benchmark ':all';
use lib './lib';
use DateTime;
use DateTime::TimeZone;

my $chicago_tz = DateTime::TimeZone->new( name => 'America/Chicago' );
my $dt = DateTime->now( time_zone => $chicago_tz );

timethis (100000, sub {
   $dt->set_time_zone('America/Chicago');
   # Reset the object for the next test
});

# before fix: timethis 100000:  8 wallclock secs ( 7.70 usr +  0.00 sys =  7.70 CPU) @ 12987.01/s (n=100000)
# after fix: timethis 100000:  0 wallclock secs ( 0.14 usr +  0.00 sys =  0.14 CPU) @ 714285.71/s (n=100000)
```
