### PR TITLE
Croak when a constructor is called on an object

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -207,6 +207,7 @@ sub new {
 
 sub _new {
     my $class = shift;
+    Carp::croak( 'Constructor called with reference, we expected a package' ) if ref $class;
     my %p     = @_;
 
     # If this method is called from somewhere other than new(), then some of

--- a/t/43new-params.t
+++ b/t/43new-params.t
@@ -82,4 +82,12 @@ like(
     'nanosecond must be an integer'
 );
 
+like(
+    exception {
+        DateTime->new( year => 10, month => 2, day => 12 )->today;
+    },
+    qr/called with reference/,
+    'constructors must be called as class methods, not object methods'
+);
+
 done_testing();


### PR DESCRIPTION
See: http://blogs.perl.org/users/preaction/2013/04/i-bless-you-in-the-name-of-the-stringified-object.html

TL;DR: If you accidentally call one of the constructors using an instance of an object, you get a confusing error message `Can't locate object method "_normalize_nanoseconds" via package "2013-04-15T00:00:00"`. The DateTime object gets stringified, and that used as the second argument to `bless` (the package argument).

This small check ensures that no references can be used to call the constructor. Tests were added to the other "new" checks. It seemed a good place.
