### PR TITLE
implement ZZZZZ CLDR code

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+- Add ZZZZZ formatter, which is like ZZZ but inserts a colon.
+
 1.04   2013-12-07
 
 - Calling set_locale() or set_formatter() on an object with an ambiguous local

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1226,6 +1226,10 @@ sub mjd { $_[0]->jd - 2_400_000.5 }
 
         qr/zzzz/   => sub { $_[0]->time_zone_long_name() },
         qr/z{1,3}/ => sub { $_[0]->time_zone_short_name() },
+        qr/ZZZZZ/  => sub {
+          substr(my $z = DateTime::TimeZone->offset_as_string(
+                $_[0]->offset() ), -2, 0, ":"); $z
+        },
         qr/ZZZZ/   => sub {
             $_[0]->time_zone_short_name()
                 . DateTime::TimeZone->offset_as_string( $_[0]->offset() );
@@ -3859,6 +3863,11 @@ The time zone offset.
 
 The time zone short name and the offset as one string, so something
 like "CDT-0500".
+
+=item * ZZZZZ
+
+The time zone offset as a sexagesimal number, so something like "-05:00".
+(This is useful for W3C format.)
 
 =item * v{1,3}
 

--- a/t/41cldr-format.t
+++ b/t/41cldr-format.t
@@ -135,6 +135,7 @@ binmode $_, ':encoding(UTF-8)'
         'vvv'  => 'CDT',
         'VVVV' => 'America/Chicago',
         'VVV'  => 'CDT',
+        'ZZZZZ' => '-05:00',
 
         q{'one fine day'} => 'one fine day',
         q{'yy''yy' yyyy}  => q{yy'yy 1976},


### PR DESCRIPTION
The actual coderef was provided by C. Hansen.  Thanks!

This lets DateTime, with no extensions, trivially produce a W3C date time with TZ offset.
