### PR TITLE
Add iso8601_with_tz method

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,14 @@ This method is equivalent to:
 
 Also available as `$dt->iso8601()`.
 
+### $dt->iso8601\_with\_tz()
+
+This method is equivalent to:
+
+    $dt->iso8601() . DateTime::TimeZone->offset_as_string( $dt->offset() )
+
+Except that the offset includes a colon separator.
+
 ### $dt->is\_leap\_year()
 
 This method returns a true or false indicating whether or not the

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -909,6 +909,21 @@ sub hms {
 sub iso8601 { join 'T', $_[0]->ymd('-'), $_[0]->hms(':') }
 *datetime = \&iso8601;
 
+sub iso8601_with_tz {
+    my $self = shift;
+
+    my $offset = $self->{tz}
+        ? DateTime::TimeZone->offset_as_string( $self->offset )
+        : '+0000';
+    $offset =~ s/^([\+\-])?(\d\d?)(\d\d)/$1$2:$3/;
+
+    return sprintf(
+        '%s%s',
+        $self->iso8601,
+        $offset
+    );
+}
+
 sub is_leap_year { $_[0]->_is_leap_year( $_[0]->year ) }
 
 sub week {
@@ -2785,6 +2800,14 @@ This method is equivalent to:
   $dt->ymd('-') . 'T' . $dt->hms(':')
 
 Also available as C<< $dt->iso8601() >>.
+
+=head3 $dt->iso8601_with_tz()
+
+This method is equivalent to:
+
+  $dt->iso8601() . DateTime::TimeZone->offset_as_string( $dt->offset() )
+
+Except that the offset includes a colon separator.
 
 =head3 $dt->is_leap_year()
 

--- a/t/03components.t
+++ b/t/03components.t
@@ -70,8 +70,9 @@ is( $d->hms,      '02:12:50', '->hms' );
 is( $d->hms('!'), '02!12!50', "->hms('!')" );
 is( $d->time,     '02:12:50', '->hms' );
 
-is( $d->datetime, '2001-07-05T02:12:50', '->datetime' );
-is( $d->iso8601,  '2001-07-05T02:12:50', '->iso8601' );
+is( $d->datetime,         '2001-07-05T02:12:50',       '->datetime' );
+is( $d->iso8601,          '2001-07-05T02:12:50',       '->iso8601' );
+is( $d->iso8601_with_tz,  '2001-07-05T02:12:50+00:00', '->iso8601_with_tz' );
 
 is( $d->is_leap_year, 0, '->is_leap_year' );
 


### PR DESCRIPTION
I had found a need to for a nice method that will output the extended format when including timezones.  I stumbled across http://www.nntp.perl.org/group/perl.datetime/2009/03/msg7222.html and I was compelled to propose a patch for DateTime.

I decided to implement an additional method called iso8601_with_tz to do this.  Please take a look at my changes and provide whatever feedback, additions, or modifications that would best suit this request.  Let me know what you think.  Thanks!
