### PR TITLE
remove dead code; tests run successfully

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1297,14 +1297,6 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
         return sprintf( "%0${size}d", $val );
     }
 
-    sub _space_padded_string {
-        my $self = shift;
-        my $size = length shift;
-        my $val  = shift;
-
-        return sprintf( "% ${size}s", $val );
-    }
-
     sub format_cldr {
         my $self = shift;
 


### PR DESCRIPTION
class of change: code clean-up

perlcritic generated several "dead code" messages, but only one of them appears to be true.

Private subroutine/method '_space_padded_string' declared but not used at line 1300, column 5.  Eliminate dead code.  (Severity: 3)

I tested all the "dead code" messages by renaming the asserted method and running prove -l. 
