### PR TITLE
Let the syntactic sugar in DateTime->add(DateTime::Duration->new(...) work again

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1713,8 +1713,8 @@ sub subtract {
     my $self = shift;
 
     my %eom;
-    if (@_ % 2 == 0) {
-        my %p    = @_;
+    if ( @_ % 2 == 0 ) {
+        my %p = @_;
 
         $eom{end_of_month} = delete $p{end_of_month}
             if exists $p{end_of_month};

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1733,9 +1733,10 @@ sub _duration_object_from_args {
     my $self = shift;
 
     my $duration;
-    if (@_ == 1 && blessed($_[0]) && $_[0]->isa( $self->duration_class ) ) {
+    if ( @_ == 1 && blessed( $_[0] ) && $_[0]->isa( $self->duration_class ) ) {
         $duration = shift;
-    } else {
+    }
+    else {
         $duration = $self->duration_class->new(@_);
     }
     return $duration;

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1711,11 +1711,14 @@ sub add {
 
 sub subtract {
     my $self = shift;
-    my %p    = @_;
 
     my %eom;
-    $eom{end_of_month} = delete $p{end_of_month}
-        if exists $p{end_of_month};
+    if (@_ % 2 == 0) {
+        my %p    = @_;
+
+        $eom{end_of_month} = delete $p{end_of_month}
+            if exists $p{end_of_month};
+    }
 
     my $dur = $self->duration_class->new(@_)->inverse(%eom);
 

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1733,7 +1733,8 @@ sub _duration_object_from_args {
     my $self = shift;
 
     my $duration;
-    if ( @_ == 1 && blessed( $_[0] ) && $_[0]->isa( $self->duration_class ) ) {
+    if ( @_ == 1 && blessed( $_[0] ) && $_[0]->isa( $self->duration_class ) )
+    {
         $duration = shift;
     }
     else {

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -3240,6 +3240,10 @@ This method is syntactic sugar around the C<add_duration()> method. It
 simply creates a new C<DateTime::Duration> object using the parameters
 given, and then calls the C<add_duration()> method.
 
+=head3 $dt->add( $duration_object )
+
+A synonym of C<< $dt->add_duration( $duration_object ) >>.
+
 =head3 $dt->subtract_duration( $duration_object )
 
 When given a C<DateTime::Duration> object, this method simply calls
@@ -3250,6 +3254,10 @@ C<add_duration> method.
 
 Like C<add()>, this is syntactic sugar for the C<subtract_duration()>
 method.
+
+=head3 $dt->subtract( $duration_object )
+
+A synonym of C<< $dt->subtract_duration( $duration_object ) >>.
 
 =head3 $dt->subtract_datetime( $datetime )
 

--- a/lib/DateTime/Duration.pm
+++ b/lib/DateTime/Duration.pm
@@ -64,7 +64,7 @@ my @all_units = qw( months days minutes seconds nanoseconds );
 
     sub new {
         my $class = shift;
-        my %p     = $check->( @_ );
+        my %p     = $check->(@_);
 
         my $self = bless {}, $class;
 

--- a/lib/DateTime/Duration.pm
+++ b/lib/DateTime/Duration.pm
@@ -64,7 +64,7 @@ my @all_units = qw( months days minutes seconds nanoseconds );
 
     sub new {
         my $class = shift;
-        my %p     = $check->( ref($_[0]) eq $class ? %{ $_[0] } : @_);
+        my %p     = $check->( @_ );
 
         my $self = bless {}, $class;
 

--- a/lib/DateTime/Duration.pm
+++ b/lib/DateTime/Duration.pm
@@ -64,7 +64,7 @@ my @all_units = qw( months days minutes seconds nanoseconds );
 
     sub new {
         my $class = shift;
-        my %p     = $check->(@_);
+        my %p     = $check->( ref($_[0]) eq $class ? %{ $_[0] } : @_);
 
         my $self = bless {}, $class;
 

--- a/t/06add.t
+++ b/t/06add.t
@@ -121,6 +121,25 @@ is( $dt->datetime, '2001-04-05T16:00:00', "Back where we started" );
 
 undef $dt;
 
+# Syntactic sugar works as well
+$dt = DateTime->new(
+    year      => 2016, month => 11, day => 11,
+    hour      => 17,
+    time_zone => 'UTC'
+);
+my $duration = DateTime::Duration->new(years => 1);
+$dt->add($duration);
+is(
+    $dt->datetime, '2017-11-11T17:00:00',
+    'Adding a Duration object via ->add works',
+);
+$duration = DateTime::Duration->new(months => 5, days => 1);
+$dt->subtract($duration);
+is(
+    $dt->datetime, '2017-06-10T17:00:00',
+    'Subtracting a Duration object via ->subtract works',
+);
+
 $dt = DateTime->new(
     year      => 1986, month  => 1, day => 28,
     hour      => 16,   minute => 38,

--- a/t/06add.t
+++ b/t/06add.t
@@ -127,13 +127,13 @@ $dt = DateTime->new(
     hour      => 17,
     time_zone => 'UTC'
 );
-my $duration = DateTime::Duration->new(years => 1);
+my $duration = DateTime::Duration->new( years => 1 );
 $dt->add($duration);
 is(
     $dt->datetime, '2017-11-11T17:00:00',
     'Adding a Duration object via ->add works',
 );
-$duration = DateTime::Duration->new(months => 5, days => 1);
+$duration = DateTime::Duration->new( months => 5, days => 1 );
 $dt->subtract($duration);
 is(
     $dt->datetime, '2017-06-10T17:00:00',


### PR DESCRIPTION
There weren't any tests for the syntactic sugar of being able to say `DateTime->add(DateTime::Duration->new(...))`, and it looks like this got broken by the switch from Params::Validate to Params::ValidationCompiler. This makes the syntactic sugar explicit rather than tacit.