### PR TITLE
The leap second in 2012 was on 2012-07-01 not 2012-06-01.

### DIFF
--- a/lib/DateTime/LeapSecond.pm
+++ b/lib/DateTime/LeapSecond.pm
@@ -108,7 +108,7 @@ sub _initialize {
             1999  Jan. 1  +1
             2006  Jan. 1  +1
             2009  Jan. 1  +1
-            2012  Jun. 1  +1
+            2012  Jul. 1  +1
             2015  Jul. 1  +1
             2017  Jan. 1  +1
             )
@@ -148,7 +148,7 @@ system was implemented.
 =item * leap_seconds( $rd )
 
 Returns the number of accumulated leap seconds for a given day,
-in the range 0 .. 22.
+in the range 0 .. 22, or more.
 
 =item * extra_seconds( $rd )
 


### PR DESCRIPTION
per https://confluence.qps.nl/display/KBE/UTC+to+GPS+Time+Correction the leap second in 2012 was on 2012-07-01 not 2012-06-01.  It's is well known that leap seconds only occur directly before Jan 1st or July 1st.