### PR TITLE
Time::Local doesn't always use Unix epoch

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -3035,8 +3035,7 @@ text.
 =head3 $dt->epoch()
 
 Return the UTC epoch value for the datetime object. Internally, this
-is implemented using C<Time::Local>, which uses the Unix epoch even on
-machines with a different epoch (such as MacOS). Datetimes before the
+is implemented using C<Time::Local>. Datetimes before the
 start of the epoch will be returned as a negative number.
 
 The return value from this method is always an integer.


### PR DESCRIPTION
Time::Local does not always use the Unix epoch, see https://github.com/houseabsolute/Time-Local/commit/24ea5f0 .
The sentence "Internally, this is implemented using Time::Local, which uses the Unix epoch even on machines with a different epoch (such as MacOS)." appears to have been in the docs since before the aforementioned change to the Time::Local docs.