### PR TITLE
Support date-time separator in datetime()

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -943,8 +943,7 @@ sub hms {
 # don't want to override CORE::time()
 *DateTime::time = sub { shift->hms(@_) };
 
-sub iso8601 { join 'T', $_[0]->ymd('-'), $_[0]->hms(':') }
-
+sub iso8601 { $_[0]->datetime('T') }
 sub datetime {
     my ($self, $sep) = @_;
     $sep = 'T' if !defined $sep;

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -944,12 +944,12 @@ sub hms {
 *DateTime::time = sub { shift->hms(@_) };
 
 sub iso8601 { $_[0]->datetime('T') }
+
 sub datetime {
-    my ($self, $sep) = @_;
+    my ( $self, $sep ) = @_;
     $sep = 'T' if !defined $sep;
     return join $sep, $self->ymd('-'), $self->hms(':');
 }
-
 
 sub is_leap_year { $_[0]->_is_leap_year( $_[0]->year ) }
 

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -944,7 +944,13 @@ sub hms {
 *DateTime::time = sub { shift->hms(@_) };
 
 sub iso8601 { join 'T', $_[0]->ymd('-'), $_[0]->hms(':') }
-*datetime = sub { $_[0]->iso8601 };
+
+sub datetime {
+    my ($self, $sep) = @_;
+    $sep = 'T' if !defined $sep;
+    return join $sep, $self->ymd('-'), $self->hms(':');
+}
+
 
 sub is_leap_year { $_[0]->_is_leap_year( $_[0]->year ) }
 
@@ -2929,14 +2935,19 @@ If no separator is specified, a colon (:) is used by default.
 
 Also available as C<< $dt->time() >>.
 
-=head3 $dt->datetime()
+=head3 $dt->datetime( $optional_separator )
 
 This method is equivalent to:
 
   $dt->ymd('-') . 'T' . $dt->hms(':')
 
+The C<$optional_separator> parameter allows you to override the separator
+between the date and time, for e.g. C<< $dt->datetime(' ') >>.
+
 This method is also available as C<< $dt->iso8601() >>, but it's not really a
-very good ISO8601 format, as it lacks a time zone.
+very good ISO8601 format, as it lacks a time zone.  If called as
+C<< $dt->iso8601() >> you cannot change the separator, as ISO8601 specifies
+that "T" must be used to separate them.
 
 =head3 $dt->is_leap_year()
 

--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -2941,7 +2941,7 @@ This method is equivalent to:
   $dt->ymd('-') . 'T' . $dt->hms(':')
 
 The C<$optional_separator> parameter allows you to override the separator
-between the date and time, for e.g. C<< $dt->datetime(' ') >>.
+between the date and time, for e.g. C<< $dt->datetime(q{ }) >>.
 
 This method is also available as C<< $dt->iso8601() >>, but it's not really a
 very good ISO8601 format, as it lacks a time zone.  If called as

--- a/lib/DateTime/Infinite.pm
+++ b/lib/DateTime/Infinite.pm
@@ -54,7 +54,7 @@ sub hour_12_0 {
     return $_[0]->_infinity_string;
 }
 
-sub iso8601 {
+sub datetime {
     return $_[0]->_infinity_string;
 }
 

--- a/t/03components.t
+++ b/t/03components.t
@@ -72,8 +72,9 @@ use DateTime;
     is( $d->time,      '02:12:50', '->hms' );
     is( $d->time('!'), '02!12!50', q{->time('!')} );
 
-    is( $d->datetime, '2001-07-05T02:12:50', '->datetime' );
-    is( $d->iso8601,  '2001-07-05T02:12:50', '->iso8601' );
+    is( $d->datetime,      '2001-07-05T02:12:50', '->datetime' );
+    is( $d->datetime(' '), '2001-07-05 02:12:50', q{->datetime(' ')} );
+    is( $d->iso8601,       '2001-07-05T02:12:50', '->iso8601' );
 
     is( $d->is_leap_year, 0, '->is_leap_year' );
 

--- a/t/03components.t
+++ b/t/03components.t
@@ -72,9 +72,9 @@ use DateTime;
     is( $d->time,      '02:12:50', '->hms' );
     is( $d->time('!'), '02!12!50', q{->time('!')} );
 
-    is( $d->datetime,      '2001-07-05T02:12:50', '->datetime' );
-    is( $d->datetime(' '), '2001-07-05 02:12:50', q{->datetime(' ')} );
-    is( $d->iso8601,       '2001-07-05T02:12:50', '->iso8601' );
+    is( $d->datetime,       '2001-07-05T02:12:50', '->datetime' );
+    is( $d->datetime(q{ }), '2001-07-05 02:12:50', q{->datetime(q{ }} );
+    is( $d->iso8601,        '2001-07-05T02:12:50', '->iso8601' );
 
     is( $d->is_leap_year, 0, '->is_leap_year' );
 


### PR DESCRIPTION
As I discussed in #54, I, and the rest of my team, often find myself writing
`$dt->ymd . ' ' . $dt->hms` because $dt->datetime uses the ISO8601 "T"
separator, which is somewhat unpleasant and not average-user-friendly.

I feel this simple change would be really helpful.

I implemented it in `datetime()` only, resulting in a tiny bit of duplicated
code, because it doesn't seem to make sense to be able to pass a separator to
`iso8601()`, when it's ISO8601 which specifies "T" as a separator, and thus
you'd be telling `iso8601()` to generate a datetime string that's not in
ISO8601 format.