### PR TITLE
Fix output of SSSS in CLDR format

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1317,15 +1317,7 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
         # I'm not sure this is what is wanted (notably the trailing
         # and leading zeros it can produce), but once again the LDML
         # spec is not all that clear.
-        qr/(S+)/ => sub {
-            my $l   = length $1;
-            my $val = sprintf(
-                "%.${l}f",
-                $_[0]->fractional_second() - $_[0]->second()
-            );
-            $val =~ s/^0\.//;
-            $val || 0;
-        },
+        qr/(S+)/ => sub { $_[0]->_format_nanosecs(length($1)) },
         qr/A+/ =>
             sub { ( $_[0]->{local_rd_secs} * 1000 ) + $_[0]->millisecond() },
 

--- a/t/41cldr-format.t
+++ b/t/41cldr-format.t
@@ -302,4 +302,24 @@ for my $o (
     }
 }
 
+{
+    my $dt = DateTime->new(
+        year       => 1976,
+        month      => 10,
+        day        => 20,
+        hour       => 18,
+        minute     => 34,
+        second     => 55,
+        nanosecond => 999_999_999,
+        locale     => 'en',
+        time_zone  => 'UTC',
+    );
+
+    is(
+        $dt->format_cldr('ss,SSS'),
+        '55,999',
+        'milliseconds are rounded down',
+    );
+}
+
 done_testing();


### PR DESCRIPTION
During the last millisecond of a second, the `SSS` specifier would produce `1.000` instead of `999`. This commit fixes that (with less code!)