### PR TITLE
Add param validation to DateTime::Duration->multiply

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 {{$NEXT}}
 
+1.47   2018-02-18
+
+- Added param validation to DateTime::Duration->multiply to only allow
+  integer multipliers.
+
+
 1.46   2018-02-11
 
 - Fixed the formatting for the CLDR "S" symbol. It could in some cases round

--- a/lib/DateTime/Duration.pm
+++ b/lib/DateTime/Duration.pm
@@ -272,17 +272,27 @@ sub _duration_object_from_args {
 
 sub subtract_duration { return $_[0]->add_duration( $_[1]->inverse ) }
 
-sub multiply {
-    my $self       = shift;
-    my $multiplier = shift;
+{
+    my $check = validation_for(
+        name   => '_check_multiply_params',
+        slurpy => 1,
+        params => [
+            { type => t('Int') },
+        ],
+    );
 
-    foreach my $u (@all_units) {
-        $self->{$u} *= $multiplier;
+    sub multiply {
+        my $self = shift;
+        my ($multiplier) = $check->(@_);
+
+        foreach my $u (@all_units) {
+            $self->{$u} *= $multiplier;
+        }
+
+        $self->_normalize_nanoseconds if $self->{nanoseconds};
+
+        return $self;
     }
-
-    $self->_normalize_nanoseconds if $self->{nanoseconds};
-
-    return $self;
 }
 
 sub compare {
@@ -540,7 +550,7 @@ object or an already-constructed duration object.
 
 =head2 $dur->multiply( $number )
 
-Multiplies each unit in the by the specified number.
+Multiplies each unit in the by the specified integer number.
 
 =head2 DateTime::Duration->compare( $duration1, $duration2, $base_datetime )
 

--- a/t/11duration.t
+++ b/t/11duration.t
@@ -307,6 +307,18 @@ my $leap_day = DateTime->new(
 }
 
 {
+    my $dur = DateTime::Duration->new( days => 29 );
+
+    like(
+        exception {
+            $dur * 5.3
+        },
+        qr/Validation failed/,
+        'non integer multiplication'
+    );
+}
+
+{
     is(
         exception {
             DateTime::Duration->new( months => 3 )->add( hours => -3 )


### PR DESCRIPTION
For #25 
It only took me a year.

Wasn't sure the best way to handle the additional overload arguments to multiply, so just set `slurpy => 1`.