### PR TITLE
Do not leave the object in a broken state after a failed add_duration

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,11 @@
 - Added is_last_day_of_quarter() and is_last_day_of_year()
   methods. Implemented by Dan Stewart. PR #72.
 
+- When an exception was thrown while adding a duration the object could be
+  left in a broken state, with the duration partially applied. Subsequent
+  addition or subtraction would produce the wrong results. Reported by Pawel
+  Pabian. GH #74.
+
 
 1.46   2018-02-11
 

--- a/t/36invalid-local.t
+++ b/t/36invalid-local.t
@@ -57,6 +57,16 @@ my $badlt_rx = qr/Invalid local time|local time [0-9\-:T]+ does not exist/;
         $badlt_rx,
         'exception for invalid time produced via add'
     );
+
+    $dt->add( days => 2 );
+
+    my $dt2 = DateTime->new(
+        year      => 2003, month => 4, day => 5,
+        hour      => 2,
+        time_zone => 'America/Chicago',
+    )->add( days => 2 );
+
+    is( $dt, $dt2, 'adding after failed addition leads to correct result' );
 }
 
 done_testing();


### PR DESCRIPTION
The addition would be partially applied, then an exception (like for an
invalid local time) could be thrown. This would leave the object in a broken
state.

Now we capture the original state of the object before attempting an addition
and roll back on an exception.