### PR TITLE
Correct stringification for infinite DateTime when different formatter is used

### DIFF
--- a/lib/DateTime/Infinite.pm
+++ b/lib/DateTime/Infinite.pm
@@ -59,7 +59,10 @@ sub datetime {
 }
 
 sub stringify {
-    return $_[0]->_infinity_string;
+    my $self = shift;
+
+    return $self->_infinity_string unless $self->{formatter};
+    return $self->{formatter}->format_datetime($self);
 }
 
 sub _infinity_string {


### PR DESCRIPTION
Test case:

	"". DateTime::Format::Pg->parse_datetime( '-infinity' )
		->set_formatter( 'DateTime::Format::Pg' )

FIXES: #121
