### PR TITLE
Fix DateTime for use without Sub::Util

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -478,8 +478,9 @@ sub _calc_local_components {
     );
 
     my $one_param_validator = validation_for(
-        name   => '_check_one_from_epoch_param',
-        params => [ { type => t('Num') } ],
+        name             => '_check_one_from_epoch_param',
+        name_is_optional => 1,
+        params           => [ { type => t('Num') } ],
     );
 
     sub from_epoch {


### PR DESCRIPTION
New `$one_param_validator` for `DateTime->from_epoch` constructor had a non-optional name, which caused an exception to be raised if `Sub::Util` was not present, such as on old perls prior to 2015 when `Sub::Util` was added to core. All of the other named validators use `name_is_optional => 1` to avoid this issue, so it looks like an oversight rather than a deliberate decision to require the name.
```
$ make test
PERL_DL_NONLAZY=1 /usr/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
# 
# Versions for all modules listed in MYMETA.json (including optional ones):
# 
# === Configure Requires ===
# 
#     Module               Want Have
#     -------------------- ---- ----
#     Dist::CheckConflicts 0.02 0.11
#     ExtUtils::MakeMaker   any 6.68
# 
# === Configure Suggests ===
# 
#     Module      Want Have
#     -------- ------- ----
#     JSON::PP 2.27300 4.07
# 
# === Build Requires ===
# 
#     Module              Want Have
#     ------------------- ---- ----
#     ExtUtils::MakeMaker  any 6.68
# 
# === Test Requires ===
# 
#     Module                    Want     Have
#     ------------------------ ----- --------
#     CPAN::Meta::Check        0.011    0.014
#     CPAN::Meta::Requirements   any    2.140
#     ExtUtils::MakeMaker        any     6.68
#     File::Spec                 any     3.40
#     Storable                   any     2.45
#     Test::Fatal                any    0.016
#     Test::More                0.96 1.302189
#     Test::Warnings           0.005    0.031
#     utf8                       any     1.09
# 
# === Test Recommends ===
# 
#     Module         Want     Have
#     ---------- -------- --------
#     CPAN::Meta 2.120900 2.150010
# 
# === Runtime Requires ===
# 
#     Module                     Want  Have
#     -------------------------- ---- -----
#     Carp                        any  1.26
#     DateTime::Locale           1.06  1.33
#     DateTime::TimeZone         2.44  2.51
#     Dist::CheckConflicts       0.02  0.11
#     POSIX                       any  1.30
#     Params::ValidationCompiler 0.26  0.30
#     Scalar::Util                any  1.27
#     Specio                     0.18  0.47
#     Specio::Declare             any  0.47
#     Specio::Exporter            any  0.47
#     Specio::Library::Builtins   any  0.47
#     Specio::Library::Numeric    any  0.47
#     Specio::Library::String     any  0.47
#     Specio::Subs                any  0.47
#     Try::Tiny                   any  0.31
#     XSLoader                    any  0.16
#     base                        any  2.18
#     integer                     any  1.00
#     namespace::autoclean       0.19  0.29
#     overload                    any  1.18
#     parent                      any 0.238
#     strict                      any  1.07
#     warnings                    any  1.13
#     warnings::register          any  1.02
# 
t/00-report-prereqs.t .... ok
#   Failed test 'use DateTime;'
#   at t/00load.t line 6.
#     Tried to use 'DateTime'.
#     Error:  Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
# Compilation failed in require at t/00load.t line 6.
# BEGIN failed--compilation aborted at t/00load.t line 6.
# Looks like you failed 1 test of 1.
t/00load.t ............... 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/01sanity.t line 6.
BEGIN failed--compilation aborted at t/01sanity.t line 6.
t/01sanity.t ............. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/02last-day.t line 7.
BEGIN failed--compilation aborted at t/02last-day.t line 7.
t/02last-day.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/03components.t line 6.
BEGIN failed--compilation aborted at t/03components.t line 6.
t/03components.t ......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/04epoch.t line 7.
BEGIN failed--compilation aborted at t/04epoch.t line 7.
t/04epoch.t .............. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/05set.t line 6.
BEGIN failed--compilation aborted at t/05set.t line 6.
t/05set.t ................ 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/06add.t line 7.
BEGIN failed--compilation aborted at t/06add.t line 7.
t/06add.t ................ 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/07compare.t line 6.
BEGIN failed--compilation aborted at t/07compare.t line 6.
t/07compare.t ............ 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/09greg.t line 6.
BEGIN failed--compilation aborted at t/09greg.t line 6.
t/09greg.t ............... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/10subtract.t line 6.
BEGIN failed--compilation aborted at t/10subtract.t line 6.
t/10subtract.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/11duration.t line 7.
BEGIN failed--compilation aborted at t/11duration.t line 7.
t/11duration.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/12week.t line 6.
BEGIN failed--compilation aborted at t/12week.t line 6.
t/12week.t ............... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/13strftime.t line 8.
BEGIN failed--compilation aborted at t/13strftime.t line 8.
t/13strftime.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/14locale.t line 7.
BEGIN failed--compilation aborted at t/14locale.t line 7.
t/14locale.t ............. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/15jd.t line 6.
BEGIN failed--compilation aborted at t/15jd.t line 6.
t/15jd.t ................. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/16truncate.t line 8.
BEGIN failed--compilation aborted at t/16truncate.t line 8.
t/16truncate.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/17set-return.t line 6.
BEGIN failed--compilation aborted at t/17set-return.t line 6.
t/17set-return.t ......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/18today.t line 6.
BEGIN failed--compilation aborted at t/18today.t line 6.
t/18today.t .............. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/19leap-second.t line 6.
BEGIN failed--compilation aborted at t/19leap-second.t line 6.
t/19leap-second.t ........ 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/20infinite.t line 6.
BEGIN failed--compilation aborted at t/20infinite.t line 6.
t/20infinite.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/21bad-params.t line 7.
BEGIN failed--compilation aborted at t/21bad-params.t line 7.
t/21bad-params.t ......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/22from-doy.t line 7.
BEGIN failed--compilation aborted at t/22from-doy.t line 7.
t/22from-doy.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/23storable.t line 6.
BEGIN failed--compilation aborted at t/23storable.t line 6.
t/23storable.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/24from-object.t line 7.
BEGIN failed--compilation aborted at t/24from-object.t line 7.
t/24from-object.t ........ 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/25add-subtract.t line 6.
BEGIN failed--compilation aborted at t/25add-subtract.t line 6.
t/25add-subtract.t ....... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime/LeapSecond.pm line 11.
BEGIN failed--compilation aborted at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime/LeapSecond.pm line 11.
Compilation failed in require at t/26dt-leapsecond-pm.t line 8.
BEGIN failed--compilation aborted at t/26dt-leapsecond-pm.t line 8.
t/26dt-leapsecond-pm.t ... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/27delta.t line 6.
BEGIN failed--compilation aborted at t/27delta.t line 6.
t/27delta.t .............. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/28dow.t line 6.
BEGIN failed--compilation aborted at t/28dow.t line 6.
t/28dow.t ................ 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/29overload.t line 8.
BEGIN failed--compilation aborted at t/29overload.t line 8.
t/29overload.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/30future-tz.t line 6.
BEGIN failed--compilation aborted at t/30future-tz.t line 6.
t/30future-tz.t .......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/31formatter.t line 7.
BEGIN failed--compilation aborted at t/31formatter.t line 7.
t/31formatter.t .......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/32leap-second2.t line 6.
BEGIN failed--compilation aborted at t/32leap-second2.t line 6.
t/32leap-second2.t ....... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/33seconds-offset.t line 6.
BEGIN failed--compilation aborted at t/33seconds-offset.t line 6.
t/33seconds-offset.t ..... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/34set-tz.t line 7.
BEGIN failed--compilation aborted at t/34set-tz.t line 7.
t/34set-tz.t ............. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/35rd-values.t line 6.
BEGIN failed--compilation aborted at t/35rd-values.t line 6.
t/35rd-values.t .......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/36invalid-local.t line 7.
BEGIN failed--compilation aborted at t/36invalid-local.t line 7.
t/36invalid-local.t ...... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/37local-add.t line 7.
BEGIN failed--compilation aborted at t/37local-add.t line 7.
t/37local-add.t .......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/38local-subtract.t line 6.
BEGIN failed--compilation aborted at t/38local-subtract.t line 6.
t/38local-subtract.t ..... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
#   Failed test 'No error loading DateTime without DateTime.so file'
#   at t/39no-so.t line 30.
#          got: 'Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
# Compilation failed in require at t/39no-so.t line 29.
# '
#     expected: undef
# Looks like you failed 1 test of 3.
t/39no-so.t .............. 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/3 subtests 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/40leap-years.t line 6.
BEGIN failed--compilation aborted at t/40leap-years.t line 6.
t/40leap-years.t ......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/41cldr-format.t line 7.
BEGIN failed--compilation aborted at t/41cldr-format.t line 7.
t/41cldr-format.t ........ 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/42duration-class.t line 6.
BEGIN failed--compilation aborted at t/42duration-class.t line 6.
t/42duration-class.t ..... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/43new-params.t line 7.
BEGIN failed--compilation aborted at t/43new-params.t line 7.
t/43new-params.t ......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/44set-formatter.t line 7.
BEGIN failed--compilation aborted at t/44set-formatter.t line 7.
t/44set-formatter.t ...... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/45core-time.t line 6.
BEGIN failed--compilation aborted at t/45core-time.t line 6.
t/45core-time.t .......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/46warnings.t line 7.
BEGIN failed--compilation aborted at t/46warnings.t line 7.
t/46warnings.t ........... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/47default-time-zone.t line 6.
BEGIN failed--compilation aborted at t/47default-time-zone.t line 6.
t/47default-time-zone.t .. 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Cannot name a generated validation subroutine. Please install Sub::Util. at /builddir/build/BUILD/DateTime-1.56/blib/lib/DateTime.pm line 480.
Compilation failed in require at t/48rt-115983.t line 7.
BEGIN failed--compilation aborted at t/48rt-115983.t line 7.
t/48rt-115983.t .......... 
Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 
Warning: DateTime::Format::Strptime did not compile at /usr/share/perl5/vendor_perl/Dist/CheckConflicts.pm line 184.
# Conflicts detected for DateTime:
#   DateTime::Format::Strptime is version unknown, but must be greater than version 1.1000
t/zzz-check-breaks.t ..... ok
Test Summary Report
-------------------
t/00load.t             (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
t/01sanity.t           (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/02last-day.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/03components.t       (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/04epoch.t            (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/05set.t              (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/06add.t              (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/07compare.t          (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/09greg.t             (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/10subtract.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/11duration.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/12week.t             (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/13strftime.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/14locale.t           (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/15jd.t               (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/16truncate.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/17set-return.t       (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/18today.t            (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/19leap-second.t      (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/20infinite.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/21bad-params.t       (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/22from-doy.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/23storable.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/24from-object.t      (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/25add-subtract.t     (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/26dt-leapsecond-pm.t (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/27delta.t            (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/28dow.t              (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/29overload.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/30future-tz.t        (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/31formatter.t        (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/32leap-second2.t     (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/33seconds-offset.t   (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/34set-tz.t           (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/35rd-values.t        (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/36invalid-local.t    (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/37local-add.t        (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/38local-subtract.t   (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/39no-so.t            (Wstat: 256 Tests: 3 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
t/40leap-years.t       (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/41cldr-format.t      (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/42duration-class.t   (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/43new-params.t       (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/44set-formatter.t    (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/45core-time.t        (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/46warnings.t         (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/47default-time-zone.t (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/48rt-115983.t        (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
Files=50, Tests=7,  7 wallclock secs ( 0.04 usr  0.02 sys +  5.88 cusr  0.42 csys =  6.36 CPU)
Result: FAIL
```
