### PR TITLE
Replace last uses of base with parent

### DIFF
--- a/lib/DateTime/Infinite.pm
+++ b/lib/DateTime/Infinite.pm
@@ -10,7 +10,7 @@ our $VERSION = '1.59';
 use DateTime;
 use DateTime::TimeZone;
 
-use base qw(DateTime);
+use parent qw(DateTime);
 
 foreach my $m (qw( set set_time_zone truncate )) {
     ## no critic (TestingAndDebugging::ProhibitNoStrict)
@@ -78,7 +78,7 @@ package DateTime::Infinite::Future;
 use strict;
 use warnings;
 
-use base qw(DateTime::Infinite);
+use parent qw(DateTime::Infinite);
 
 {
     my $Pos = bless {
@@ -103,7 +103,7 @@ package DateTime::Infinite::Past;
 use strict;
 use warnings;
 
-use base qw(DateTime::Infinite);
+use parent qw(DateTime::Infinite);
 
 {
     my $Neg = bless {

--- a/t/42duration-class.t
+++ b/t/42duration-class.t
@@ -9,12 +9,12 @@ undef $ENV{PERL_DATETIME_DEFAULT_TZ};
 
 {
     package DateTime::MySubclass;
-    use base 'DateTime';
+    use parent 'DateTime';
 
     sub duration_class {'DateTime::Duration::MySubclass'}
 
     package DateTime::Duration::MySubclass;
-    use base 'DateTime::Duration';
+    use parent 'DateTime::Duration';
 
     sub is_my_subclass {1}
 }


### PR DESCRIPTION
We already depend on parent so let's drop this legacy dep and save a little RAM.