### PR TITLE
Simplify some CLDR pattern methods

### DIFF
--- a/lib/DateTime.pm
+++ b/lib/DateTime.pm
@@ -1245,7 +1245,7 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
             $y2 *= -1 if $year < 0;
             $_[0]->_zero_padded_number( 'yy', $y2 );
         },
-        qr/y/    => sub { $_[0]->year },
+        qr/y/    => 'year',
         qr/(u+)/ => sub { $_[0]->_zero_padded_number( $1, $_[0]->year ) },
         qr/(Y+)/ =>
             sub { $_[0]->_zero_padded_number( $1, $_[0]->week_year ) },
@@ -1346,8 +1346,8 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
         qr/A+/   =>
             sub { ( $_[0]->{local_rd_secs} * 1000 ) + $_[0]->millisecond },
 
-        qr/zzzz/   => sub { $_[0]->time_zone_long_name },
-        qr/z{1,3}/ => sub { $_[0]->time_zone_short_name },
+        qr/zzzz/   => 'time_zone_long_name',
+        qr/z{1,3}/ => 'time_zone_short_name',
         qr/ZZZZZ/  => sub {
             DateTime::TimeZone->offset_as_string( $_[0]->offset, q{:} );
         },
@@ -1357,10 +1357,10 @@ sub jd { $_[0]->mjd + 2_400_000.5 }
         },
         qr/Z{1,3}/ =>
             sub { DateTime::TimeZone->offset_as_string( $_[0]->offset ) },
-        qr/vvvv/   => sub { $_[0]->time_zone_long_name },
-        qr/v{1,3}/ => sub { $_[0]->time_zone_short_name },
-        qr/VVVV/   => sub { $_[0]->time_zone_long_name },
-        qr/V{1,3}/ => sub { $_[0]->time_zone_short_name },
+        qr/vvvv/   => 'time_zone_long_name',
+        qr/v{1,3}/ => 'time_zone_short_name',
+        qr/VVVV/   => 'time_zone_long_name',
+        qr/V{1,3}/ => 'time_zone_short_name',
     );
 
     sub _zero_padded_number {


### PR DESCRIPTION
The right hand side of `@patterns` can be either a subref or a method name, either way it'll be invoked as a method. By just using the method name where we can we avoid one level of indirection. Subclassing is unaffected.